### PR TITLE
Fixed bug with duplicating piece when starting drag instantly after drop.

### DIFF
--- a/js/chessboard.js
+++ b/js/chessboard.js
@@ -970,6 +970,7 @@ function drawPositionInstant() {
   // add the pieces
   for (var i in CURRENT_POSITION) {
     if (CURRENT_POSITION.hasOwnProperty(i) !== true) continue;
+	if (DRAGGING_A_PIECE && DRAGGED_PIECE_SOURCE == i) continue;
 
     $('#' + SQUARE_ELS_IDS[i]).append(buildPiece(CURRENT_POSITION[i]));
   }


### PR DESCRIPTION
If start dragging right after stop, and animation is enabled, the piece gets duplicated after animation is ended. Fixed that by adding condition to the function drawPositionInstant.
