### PR TITLE
add webkit prefix rule to board style

### DIFF
--- a/css/chessboard.css
+++ b/css/chessboard.css
@@ -16,6 +16,7 @@
 /* board */
 .board-b72b1 {
   border: 2px solid #404040;
+  -webkit-box-sizing: content-box;
   -moz-box-sizing: content-box;
   box-sizing: content-box;
 }


### PR DESCRIPTION
When using bootstrap and chessboard.js, the board messed up on Android's built in browser, this fixes 
that issue.

![sc20131121-210208](https://f.cloud.github.com/assets/3333527/1597818/b85a55f4-531a-11e3-9b4b-d566cf970a58.png)
