### PR TITLE
bug fix for when move() is called without any moves, the ANIMATION_HAPPE...

### DIFF
--- a/js/chessboard.js
+++ b/js/chessboard.js
@@ -772,6 +772,10 @@ function animateSparePieceToSquare(piece, dest, completeFn) {
 
 // execute an array of animations
 function doAnimations(a, oldPos, newPos) {
+  if (a.length == 0) {
+    return;
+  }
+
   ANIMATION_HAPPENING = true;
 
   var numFinished = 0;


### PR DESCRIPTION
...NING state variable would be left permanently true.
