### PR TITLE
Changing call to .css('width') to .width()

### DIFF
--- a/js/chessboard.js
+++ b/js/chessboard.js
@@ -499,7 +499,7 @@ function expandConfig() {
 // fudge factor, and then keep reducing until we find an exact mod 8 for
 // our square size
 function calculateSquareSize() {
-  var containerWidth = parseInt(containerEl.css('width'), 10);
+  var containerWidth = parseInt(containerEl.width(), 10);
 
   // defensive, prevent infinite loop
   if (! containerWidth || containerWidth <= 0) {


### PR DESCRIPTION
Per the jQuery docs (http://api.jquery.com/width/):

```
    The difference between .css(width) and .width() is that the latter returns a
    unit-less pixel value (for example, 400) while the former returns a value with
    units intact (for example, 400px). The .width() method is recommended when an
    element's width needs to be used in a mathematical calculation.
```
