### PR TITLE
.move() can now handle c5-c6#, Bc6-Bd5+ and many more

### DIFF
--- a/js/chessboard.js
+++ b/js/chessboard.js
@@ -1341,6 +1341,11 @@ widget.move = function() {
       continue;
     }
 
+    // Allow user to input something like this: c5-c6# or even Bc6-Bd5+
+    var move = arguments[i].split('-');
+    move.forEach(function(s, index) { if (s.length === 3) move[index] = s.substr(1); else if (s.length === 4) move[index] = s.substr(1, 2); });
+    arguments[i] = move.join('-');
+
     // skip invalid arguments
     if (validMove(arguments[i]) !== true) {
       error(2826, 'Invalid move passed to the move method.', arguments[i]);


### PR DESCRIPTION
Since `game.history()` (Chess.js) can return something like this `["Bd5+", "Rf7", "Qe8#"]` it would be nice to pass `Bd5+` and `Qe8#` (plus their original position) directly into board.move().

As of today board.move only accepts something like `'c6-d5'`, but not `'Bc6-Bd5+'`.

Therefore I have created a dirty fix for that, since I don't know your complete structure and I would have to add the code to the `validMove` function as well as the `calculatePositionFromMoves` function.

If you find that feature cool, maybe you can integrate it.
