### PR TITLE
fix - drag durring opponent's turn

### DIFF
--- a/js/chessboard.js
+++ b/js/chessboard.js
@@ -975,7 +975,8 @@ function drawPositionInstant() {
   for (var i in CURRENT_POSITION) {
     if (CURRENT_POSITION.hasOwnProperty(i) !== true) continue;
 
-    $('#' + SQUARE_ELS_IDS[i]).append(buildPiece(CURRENT_POSITION[i]));
+    if(!DRAGGING_A_PIECE || i !== DRAGGED_PIECE_SOURCE)
+      $('#' + SQUARE_ELS_IDS[i]).append(buildPiece(CURRENT_POSITION[i]));
   }
 }
 


### PR DESCRIPTION
Sorry for my language.
Bug - When player drag piece durring opponent's turn, piece appears on board after opponent's move. 
Decision - It is check position on source dragged.
