### PR TITLE
update position before firing onChange

### DIFF
--- a/www/js/chessboard.js
+++ b/www/js/chessboard.js
@@ -1023,14 +1023,15 @@ function setCurrentPosition(position) {
   // do nothing if no change in position
   if (oldFen === newFen) return;
 
+  // update state
+  CURRENT_POSITION = position;
+  
   // run their onChange function
   if (cfg.hasOwnProperty('onChange') === true &&
     typeof cfg.onChange === 'function') {
     cfg.onChange(oldPos, newPos);
   }
-
-  // update state
-  CURRENT_POSITION = position;
+  
 }
 
 function isXYOnSquare(x, y) {
@@ -1286,11 +1287,6 @@ function stopDraggedPiece(location) {
   }
   else if (action === 'drop') {
     dropDraggedPieceOnSquare(location);
-  }
-  // run their onMoveEnd function
-  if (cfg.hasOwnProperty('onMoveEnd') === true &&
-    typeof cfg.onMoveEnd === 'function') {
-    cfg.onMoveEnd(deepCopy(deepCopy(CURRENT_POSITION)), deepCopy(newPosition));
   }
 }
 

--- a/www/js/chessboard.js
+++ b/www/js/chessboard.js
@@ -1287,6 +1287,11 @@ function stopDraggedPiece(location) {
   else if (action === 'drop') {
     dropDraggedPieceOnSquare(location);
   }
+  // run their onMoveEnd function
+  if (cfg.hasOwnProperty('onMoveEnd') === true &&
+    typeof cfg.onMoveEnd === 'function') {
+    cfg.onMoveEnd(deepCopy(deepCopy(CURRENT_POSITION)), deepCopy(newPosition));
+  }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This allows you to run <code>widget.fen()</code> and get the FEN string that matches <code>Chessboard.objToFen(newPos)</code>. Without it calling <code>widget.fen()</code> within the <code>onChange()</code> event returns the value that matches <code>Chessboard.objToFen(oldPos)</code>.