### PR TITLE
Add showNotation() method

### DIFF
--- a/www/js/chessboard.js
+++ b/www/js/chessboard.js
@@ -1458,7 +1458,13 @@ widget.resize = function() {
 widget.start = function(useAnimation) {
   widget.position('start', useAnimation);
 };
-
+  
+// turn notation on or off
+widget.showNotation = function(show) {
+  cfg.showNotation = show;
+  drawBoard();
+}
+  
 //------------------------------------------------------------------------------
 // Browser Events
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Use case: I'm building a PGN viewer and want to give the user the option to turn the board notation on or off. Requires redrawing the board, but can't think of any reason why that should be a problem?