### PR TITLE
Stopped touch window movement while dragging a piece

### DIFF
--- a/src/chessboard.js
+++ b/src/chessboard.js
@@ -1610,7 +1610,6 @@
       if (!currentPosition.hasOwnProperty(square)) return
 
       e.preventDefault();
-      e.stopPropagation();
       e = e.originalEvent
       beginDraggingPiece(
           square,

--- a/src/chessboard.js
+++ b/src/chessboard.js
@@ -1609,6 +1609,8 @@
       if (!validSquare(square)) return
       if (!currentPosition.hasOwnProperty(square)) return
 
+      e.preventDefault();
+      e.stopPropagation();
       e = e.originalEvent
       beginDraggingPiece(
           square,
@@ -1632,7 +1634,6 @@
       if (!config.sparePieces) return
 
       var piece = $(this).attr('data-piece')
-
       e = e.originalEvent
       beginDraggingPiece(
           'spare',


### PR DESCRIPTION
I added 
      e.preventDefault();
      e.stopPropagation();
to the "touchstartSquare" function when a valid piece is targeted. This works on most mobile devices I have tested with including Chrome/Android and iOS devices.