### PR TITLE
The change is in response to issue #74

### DIFF
--- a/lib/chessboard.js
+++ b/lib/chessboard.js
@@ -1653,10 +1653,6 @@
     function touchmoveWindow (evt) {
       // do nothing if we are not dragging a piece
       if (!isDragging) return
-
-      // prevent screen from scrolling
-      //  evt.preventDefault()
-
       updateDraggedPiece(evt.originalEvent.changedTouches[0].pageX,
         evt.originalEvent.changedTouches[0].pageY)
     }

--- a/lib/chessboard.js
+++ b/lib/chessboard.js
@@ -1655,7 +1655,7 @@
       if (!isDragging) return
 
       // prevent screen from scrolling
-      evt.preventDefault()
+      //  evt.preventDefault()
 
       updateDraggedPiece(evt.originalEvent.changedTouches[0].pageX,
         evt.originalEvent.changedTouches[0].pageY)


### PR DESCRIPTION
The commit removes call evt.preventDefault() from the touchmoveWindow function
as this call will be ignored as per the below feature request and the screen stays scrollable.
https://chromestatus.com/feature/5093566007214080
Screen scrolling can be stopped by using the callback method onDragStart and onDrag by adding and removing CSS property "overflow:hidden;" on the body tag